### PR TITLE
addresses #1 - change splash page category tag to match EW categories.txt

### DIFF
--- a/SharpWitness/Program.cs
+++ b/SharpWitness/Program.cs
@@ -150,7 +150,7 @@ namespace SharpWitness
             categoryRankDict.Add("voip", new object[] { "Voice/Video over IP (VoIP)", 0 });
             categoryRankDict.Add("None", new object[] { "Uncategorized", 0 });
             categoryRankDict.Add("uncat", new object[] { "Uncategorized", 0 });
-            categoryRankDict.Add("crap", new object[] { "Splash Pages", 0 });
+            categoryRankDict.Add("splash", new object[] { "Splash Pages", 0 });
             categoryRankDict.Add("printer", new object[] { "Printers", 0 });
             categoryRankDict.Add("camera", new object[] { "Cameras", 0 });
             categoryRankDict.Add("infrastructure", new object[] { "Infrastructure", 0 });


### PR DESCRIPTION
When PR https://github.com/RedSiege/EyeWitness/pull/712 is merged, merge this PR as well.  It updates the SharpWitness code to expect category "splash" which was changed form "crap" in EW PR 712/..

related to
https://github.com/RedSiege/SharpWitness/issues/1
https://github.com/RedSiege/EyeWitness/issues/711
https://github.com/RedSiege/EyeWitness/pull/712